### PR TITLE
chore(types): don't smash globby types

### DIFF
--- a/lib/utils/file-searcher.ts
+++ b/lib/utils/file-searcher.ts
@@ -23,7 +23,7 @@ export default class FileSearcher {
   }
 
   _getSearchItem(pattern: string): Promise<string[]> {
-    let patterns: string[] = this.searchPatterns[pattern].concat(IGNORE_PATTERNS);
+    let patterns = this.searchPatterns[pattern].concat(IGNORE_PATTERNS);
     return globby(patterns);
   }
 }

--- a/types/globby/index.d.ts
+++ b/types/globby/index.d.ts
@@ -1,1 +1,0 @@
-declare module 'globby';


### PR DESCRIPTION
globby now supplies its own type definitions, which the existing module definition was invisibly smashing; removing it allows the native types shipped with the package to work correctly.